### PR TITLE
Refactor EventDetailsModal and remove Visioning Workshop references

### DIFF
--- a/app/components/EventDetailsModal.tsx
+++ b/app/components/EventDetailsModal.tsx
@@ -11,7 +11,7 @@ import {
 } from "@ant-design/icons";
 import Image from "next/image";
 import type { EventItem } from "./EventCard";
-import { markBooked, VISIONING_WORKSHOP_EVENT_ID } from "./PhysicalEventPromoModal";
+import { markBooked } from "./PhysicalEventPromoModal";
 
 export default function EventDetailsModal({
   open,
@@ -124,10 +124,7 @@ export default function EventDetailsModal({
                 target={link.startsWith("http") ? "_blank" : undefined}
                 rel={link.startsWith("http") ? "noopener noreferrer" : undefined}
                 onClick={() => {
-                  // Mark as booked if this is the Visioning Workshop event
-                  if (event.title === "Visioning Workshop") {
-                    markBooked(VISIONING_WORKSHOP_EVENT_ID);
-                  }
+                  // Handle booking tracking if needed
                 }}
                 className="inline-flex items-center gap-1 text-[var(--yplus-primary,#d0a328)] border border-[var(--yplus-primary,#d0a328)] rounded-full px-3 py-1 cursor-pointer hover:bg-[var(--yplus-primary,#d0a328)] hover:text-black transition-colors"
               >

--- a/app/content/connect2026.ts
+++ b/app/content/connect2026.ts
@@ -42,7 +42,7 @@ export const CONNECT_2026: ConnectMonth[] = [
         imageSrc: "/images/visioning_poster.png",
         description: "Join us for an immersive in-person workshop to set your vision for 2026.",
         details: "Transform your aspirations into a clear, actionable vision. This physical event brings together goal-setters, visionaries, and changemakers for a hands-on workshop experience.",
-        link: "https://youthplusafrica.hustlesasa.shop/?product=72677", // TODO: Update with actual booking URL
+        link: "https://youthplusafrica.hustlesasa.shop/?product=72677",
         hasFutureEvents: true,
       },
     ],

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -5,10 +5,8 @@ import HeaderNav from "../components/HeaderNav";
 import SectionWithBg from "../components/SectionWithBg";
 import MonthRowLayout from "../components/MonthRowLayout";
 import EventCard from "../components/EventCard";
-import EventPromoBanner from "../components/EventPromoBanner";
 import { CONNECT_2026 } from "../content/connect2026";
 import { PAST_EVENTS } from "../content/events";
-import { VISIONING_WORKSHOP_EVENT_ID } from "../components/PhysicalEventPromoModal";
 
 export default function EventsPage() {
   // Get today's date string in Kenya/EAT timezone (Africa/Nairobi)
@@ -59,15 +57,6 @@ export default function EventsPage() {
         className="py-12 md:py-16"
       >
         <div className="mx-auto max-w-6xl px-6">
-          {/* Visioning Workshop Promo Banner */}
-          <EventPromoBanner
-            eventId={VISIONING_WORKSHOP_EVENT_ID}
-            posterImage="/images/visioning_poster.png"
-            title="Visioning Workshop"
-            description="Join us for an immersive in-person workshop to set your vision for 2026. Transform your aspirations into a clear, actionable vision."
-            bookingUrl="https://youthplusafrica.hustlesasa.shop/?product=72677"
-          />
-
           {upcomingMonths.length > 0 ? (
             <MonthRowLayout
               months={upcomingMonths}

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -8,22 +8,12 @@ import ImpactTrack from "../components/ImpactTrack";
 import PartnersStrip from "../components/PartnersStrip";
 import FooterMain from "../components/FooterMain";
 // import JoinCommunityPopup from "../components/JoinCommunityPopup";
-import PhysicalEventPromoModal, {
-  VISIONING_WORKSHOP_EVENT_ID,
-} from "../components/PhysicalEventPromoModal";
 
 export default function Home() {
   return (
     <div className="min-h-screen w-full">
       <HeaderNav />
       {/* <JoinCommunityPopup /> */}
-      <PhysicalEventPromoModal
-        eventId={VISIONING_WORKSHOP_EVENT_ID}
-        posterImage="/images/visioning_poster.png"
-        title="Visioning Workshop"
-        description="Join us for an immersive in-person workshop to set your vision for 2026. Transform your aspirations into a clear, actionable vision."
-        bookingUrl="https://youthplusafrica.hustlesasa.shop/?product=72677"
-      />
       {/* <CallForSpeakersModal /> */}
       <Hero
         title="Empowering Africa’s youth to build, create, and lead."


### PR DESCRIPTION
- Removed specific booking logic for the Visioning Workshop from EventDetailsModal.
- Updated connect2026.ts to maintain the booking URL for the workshop.
- Eliminated the EventPromoBanner for the Visioning Workshop from EventsPage and Home components for a cleaner layout.